### PR TITLE
Fixed file finding

### DIFF
--- a/static/genapp-jbrowse/app/services.js
+++ b/static/genapp-jbrowse/app/services.js
@@ -172,7 +172,7 @@ angular.module('jbrowse.services', ['ngResource', 'genjs.services'])
         api.find = function (item, propPath, pattern) {
             var entries = _.path(item, propPath);
             if (!_.isArray(entries)) entries = [entries];
-            return _.find(entries, RegExp.test, pattern) || false;
+            return _.find(entries, _.bind(pattern.test, pattern)) || false;
         };
 
         api.patterns = commonPatterns;


### PR DESCRIPTION
_.find(arr, RegExp.test, /..../) does not work after all. Always returns the first element of array. Noticed the error when trying to load VCF file.
