### PR TITLE
Support bam's bigwig from bigwigcalculation processor

### DIFF
--- a/static/genapp-jbrowse/app/controllers.js
+++ b/static/genapp-jbrowse/app/controllers.js
@@ -88,7 +88,7 @@ angular.module('jbrowse.controllers', ['genjs.services', 'jbrowse.services'])
         };
 
         var config = {
-            'data:alignment:bam:bigwig': {
+            'data:reads:bigwig:': {
                 min_score: 0,
                 max_score: 35
             }

--- a/static/genapp-jbrowse/app/directives.js
+++ b/static/genapp-jbrowse/app/directives.js
@@ -128,15 +128,25 @@ angular.module('jbrowse.directives', ['genjs.services', 'jbrowse.services'])
                             baiUrlTemplate: url + escUrl(item.output.bai.file),
                             label: item.static.name
                         }, config).then(function () {
+                            // backwards compatibility
                             var bigWigFile = supportedTypes.find(item, 'output.bam.refs', supportedTypes.patterns['bigWig']);
-                            return bigWigFile && addTrack({
-                                genialisType: item.type + 'bigwig:',
-                                type: 'JBrowse/View/Track/Wiggle/XYPlot',
-                                storeClass: 'JBrowse/Store/SeqFeature/BigWig',
-                                label: item.static.name + ' Coverage',
-                                urlTemplate: url + escUrl(bigWigFile)
+                            return bigWigFile && $scope.options.addTrack({
+                                id: item.id,
+                                type: 'data:reads:bigwig:',
+                                static: { name: item.static.name + ' Coverage' },
+                                output: { bigwig: { file: bigWigFile } }
                             }, config);
                         });
+                    },
+                    'data:reads:bigwig:': function (item, config) {
+                        var url = API_DATA_URL + item.id + '/download/';
+                        return addTrack({
+                            genialisType: item.type,
+                            type: 'JBrowse/View/Track/Wiggle/XYPlot',
+                            storeClass: 'JBrowse/Store/SeqFeature/BigWig',
+                            label: item.static.name,
+                            urlTemplate: url + escUrl(item.output.bigwig.file)
+                        }, config);
                     },
                     'data:expression:polya:': function (item, config) {
                         var url = API_DATA_URL + item.id + '/download/',


### PR DESCRIPTION
Requires: https://github.com/genialis/genesis/pull/302

Allows adding a BAM's BigWig track as a separate data object.
Previously it was in the same data object, inside refs.

Also added backward compatibility (for BAMs that already have BigWig inside refs)
